### PR TITLE
Bumps versions used in README.md to 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Build Docker images
-        uses: hiberbee/github-action-skaffold@1.8.0
+        uses: hiberbee/github-action-skaffold@1.12.0
         with:
           command: build
           repository: ghcr.io/hiberbee/docker
@@ -99,7 +99,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run Skaffold pipeline as action
-        uses: hiberbee/github-action-skaffold@1.6.0
+        uses: hiberbee/github-action-skaffold@1.12.0
         with:
           command: run
           repository: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
I assumed the latest stable version was used in the README, but seems they were outdated. Bumped them to prevent future users running into the same problem. :-)